### PR TITLE
feat: add docs crawler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ __pycache__
 .aider*
 .idea/
 *.vsix
+/.history
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,17 @@
       "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "nanoid": "^3.3.7"
+        "@types/puppeteer": "^5.4.7",
+        "nanoid": "^3.3.7",
+        "puppeteer": "^23.8.0"
       },
       "devDependencies": {
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/exec": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
         "@types/mocha": "^10.0.7",
-        "@types/node": "20.x",
-        "@types/vscode": "^1.93.0",
+        "@types/node": "^20.17.6",
+        "@types/vscode": "^1.95.0",
         "@typescript-eslint/eslint-plugin": "^8.3.0",
         "@typescript-eslint/parser": "^8.3.0",
         "@vscode/test-cli": "^0.0.10",
@@ -27,7 +29,7 @@
         "eslint": "^9.9.1",
         "prettier": "^3.3.3",
         "semantic-release": "^24.2.0",
-        "typescript": "^5.5.4"
+        "typescript": "^5.6.3"
       },
       "engines": {
         "vscode": "^1.93.0"
@@ -197,7 +199,6 @@
       "version": "7.26.2",
       "resolved": "https://registry.npmmirror.com/@babel/code-frame/-/code-frame-7.26.2.tgz",
       "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.25.9",
         "js-tokens": "^4.0.0",
@@ -211,7 +212,6 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmmirror.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
       "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -708,6 +708,53 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.4.1.tgz",
+      "integrity": "sha512-0kdAbmic3J09I6dT8e9vE2JOCSt13wHCW5x/ly8TSt2bDtuIWe2TgLZZDHdcziw9AVCzflMAXCrVyRIhIs44Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.3.7",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.4.0",
+        "semver": "^7.6.3",
+        "tar-fs": "^3.0.6",
+        "unbzip2-stream": "^1.4.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/tar-fs": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.6.tgz",
+      "integrity": "sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^2.1.1",
+        "bare-path": "^2.1.0"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
       }
     },
     "node_modules/@sec-ant/readable-stream": {
@@ -1215,6 +1262,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmmirror.com/@types/estree/-/estree-1.0.6.tgz",
@@ -1240,10 +1293,10 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.16.9",
-      "resolved": "https://registry.npmmirror.com/@types/node/-/node-20.16.9.tgz",
-      "integrity": "sha512-rkvIVJxsOfBejxK7I0FO5sa2WxFmJCzoDwcd88+fq/CUfynNywTo/1/T6hyFz22CyztsnLS9nVlHOnTI36RH5w==",
-      "dev": true,
+      "version": "20.17.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.6.tgz",
+      "integrity": "sha512-VEI7OdvK2wP7XHnsuXbAJnEpEkF6NjSN45QJlL4VGqZSXsnicpesdTWsg9RISeSdYd3yeRj/y3k5KGjUXYnFwQ==",
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -1254,6 +1307,15 @@
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true
     },
+    "node_modules/@types/puppeteer": {
+      "version": "5.4.7",
+      "resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-5.4.7.tgz",
+      "integrity": "sha512-JdGWZZYL0vKapXF4oQTC5hLVNfOgdPrqeZ1BiQnGk5cB7HeE91EWUiTdVSdQPobRN8rIcdffjiOgCYJ/S8QrnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/semver": {
       "version": "7.5.8",
       "resolved": "https://registry.npmmirror.com/@types/semver/-/semver-7.5.8.tgz",
@@ -1261,10 +1323,21 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.93.0",
-      "resolved": "https://registry.npmmirror.com/@types/vscode/-/vscode-1.93.0.tgz",
-      "integrity": "sha512-kUK6jAHSR5zY8ps42xuW89NLcBpw1kOabah7yv38J8MyiYuOHxLQBi0e7zeXbQgVefDy/mZZetqEFC+Fl5eIEQ==",
-      "dev": true
+      "version": "1.95.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.95.0.tgz",
+      "integrity": "sha512-0LBD8TEiNbet3NvWsmn59zLzOFu/txSlGxnv5yAFHCrhG9WvAnR3IvfHzMOs2aeWqgvNjq9pO99IUw8d3n+unw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.7.0",
@@ -1473,9 +1546,10 @@
     },
     "node_modules/@vscode/test-electron": {
       "version": "2.4.1",
-      "resolved": "https://registry.npmmirror.com/@vscode/test-electron/-/test-electron-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.4.1.tgz",
       "integrity": "sha512-Gc6EdaLANdktQ1t+zozoBVRynfIsMKMc94Svu1QreOBC8y76x4tvaK32TljrLi1LI2+PK58sDVbL7ALdqf3VRQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "http-proxy-agent": "^7.0.2",
         "https-proxy-agent": "^7.0.5",
@@ -1859,7 +1933,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmmirror.com/agent-base/-/agent-base-7.1.1.tgz",
       "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
-      "dev": true,
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -1924,7 +1997,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmmirror.com/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -1933,7 +2005,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmmirror.com/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -1966,8 +2037,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmmirror.com/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/argv-formatter": {
       "version": "1.0.0",
@@ -1980,6 +2050,18 @@
       "resolved": "https://registry.npmmirror.com/array-ify/-/array-ify-1.0.0.tgz",
       "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
       "dev": true
+    },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -1997,17 +2079,68 @@
         "typed-rest-client": "^1.8.4"
       }
     },
+    "node_modules/b4a": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
+      "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmmirror.com/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/bare-events": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.0.tgz",
+      "integrity": "sha512-/E8dDe9dsbLyh2qrZ64PEPadOQ0F4gbl1sUJOrmph7xOiIxfY8vwab/4bFLh4Y88/Hk/ujKcrQKc+ps0mv873A==",
+      "license": "Apache-2.0",
+      "optional": true
+    },
+    "node_modules/bare-fs": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.5.tgz",
+      "integrity": "sha512-SlE9eTxifPDJrT6YgemQ1WGFleevzwY+XAP1Xqgl56HtcrisC2CHCZ2tq6dBpcH2TnNxwUEUGhweo+lrQtYuiw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-events": "^2.0.0",
+        "bare-path": "^2.0.0",
+        "bare-stream": "^2.0.0"
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.4.4.tgz",
+      "integrity": "sha512-z3UiI2yi1mK0sXeRdc4O1Kk8aOa/e+FNWZcTiPB/dfTWyLypuE99LibgRaQki914Jq//yAWylcAt+mknKdixRQ==",
+      "license": "Apache-2.0",
+      "optional": true
+    },
+    "node_modules/bare-path": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-2.1.3.tgz",
+      "integrity": "sha512-lh/eITfU8hrj9Ru5quUp0Io1kJWIk1bTjzo7JH1P5dWmQ2EL4hFUlfI8FonAhSlgIfhn63p84CDY/x+PisgcXA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-os": "^2.1.0"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.3.2.tgz",
+      "integrity": "sha512-EFZHSIBkDgSHIwj2l2QZfP4U5OcD4xFAOwhSb/vlr9PIqyGJGvB/nfClJbcnh3EY4jtPE4zsb5ztae96bVF79A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "streamx": "^2.20.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmmirror.com/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2022,6 +2155,15 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
+      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/before-after-hook": {
       "version": "3.0.2",
@@ -2133,7 +2275,6 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmmirror.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -2192,7 +2333,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmmirror.com/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -2318,6 +2458,20 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/chromium-bidi": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.8.0.tgz",
+      "integrity": "sha512-uJydbGdTw0DEUjhoogGveneJVWX/9YuqkWePzMmkBYwtdAqo5d3J/ovNKFr+/2hWXYmYCr6it8mSSTIj6SS6Ug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "3.0.1",
+        "urlpattern-polyfill": "10.0.0",
+        "zod": "3.23.8"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
@@ -2511,7 +2665,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmmirror.com/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -2524,14 +2677,12 @@
     "node_modules/cliui/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmmirror.com/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/cliui/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmmirror.com/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -2545,7 +2696,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -2571,7 +2721,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmmirror.com/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2582,8 +2731,7 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmmirror.com/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -2715,7 +2863,6 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmmirror.com/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
-      "dev": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -2824,11 +2971,19 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/debug": {
       "version": "4.3.7",
       "resolved": "https://registry.npmmirror.com/debug/-/debug-4.3.7.tgz",
       "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dev": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -2910,6 +3065,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmmirror.com/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -2928,6 +3097,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1367902",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1367902.tgz",
+      "integrity": "sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/diff": {
       "version": "5.2.0",
@@ -3070,8 +3245,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmmirror.com/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
-      "optional": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -3240,7 +3413,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmmirror.com/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -3261,7 +3433,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmmirror.com/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
@@ -3291,7 +3462,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmmirror.com/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -3306,6 +3476,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
       }
     },
     "node_modules/eslint": {
@@ -3473,6 +3664,19 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.6.0",
       "resolved": "https://registry.npmmirror.com/esquery/-/esquery-1.6.0.tgz",
@@ -3501,7 +3705,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmmirror.com/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -3510,7 +3713,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmmirror.com/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3563,11 +3765,52 @@
         "node": ">=6"
       }
     },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extract-zip/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmmirror.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
@@ -3610,7 +3853,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmmirror.com/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
       "dependencies": {
         "pend": "~1.2.0"
       }
@@ -3789,7 +4031,6 @@
       "version": "11.2.0",
       "resolved": "https://registry.npmmirror.com/fs-extra/-/fs-extra-11.2.0.tgz",
       "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -3844,7 +4085,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmmirror.com/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -3878,6 +4118,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.3.tgz",
+      "integrity": "sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==",
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4",
+        "fs-extra": "^11.2.0"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/git-log-parser": {
@@ -3992,8 +4247,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmmirror.com/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -4162,7 +4416,6 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmmirror.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -4175,7 +4428,6 @@
       "version": "7.0.5",
       "resolved": "https://registry.npmmirror.com/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
       "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
-      "dev": true,
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "4"
@@ -4209,7 +4461,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmmirror.com/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4244,7 +4495,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmmirror.com/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-      "dev": true,
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -4348,11 +4598,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmmirror.com/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -4394,7 +4656,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmmirror.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -4598,20 +4859,24 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmmirror.com/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmmirror.com/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "license": "MIT"
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
@@ -4628,8 +4893,7 @@
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmmirror.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -4653,7 +4917,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmmirror.com/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -4792,8 +5055,7 @@
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmmirror.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "node_modules/linkify-it": {
       "version": "5.0.0",
@@ -5170,6 +5432,12 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmmirror.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
@@ -5337,8 +5605,7 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmmirror.com/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/mute-stream": {
       "version": "0.0.8",
@@ -5398,6 +5665,15 @@
       "resolved": "https://registry.npmmirror.com/nerf-dart/-/nerf-dart-1.0.0.tgz",
       "integrity": "sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==",
       "dev": true
+    },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/node-abi": {
       "version": "3.71.0",
@@ -8664,7 +8940,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmmirror.com/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -8927,6 +9202,38 @@
         "node": ">=4"
       }
     },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-BFi3vZnO9X5Qt6NRz7ZOaPja3ic0PhlsmCRYLOpN11+mWBCR6XJDqW5RF3j8jm4WGGQZtBA+bTfxYzeKW73eHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.0.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.5",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.0",
       "resolved": "https://registry.npmmirror.com/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
@@ -8943,7 +9250,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmmirror.com/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -8955,7 +9261,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmmirror.com/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -9091,14 +9396,12 @@
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmmirror.com/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmmirror.com/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -9264,18 +9567,59 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmmirror.com/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
       "dev": true
     },
+    "node_modules/proxy-agent": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
+      "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.3",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.0.1",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
     "node_modules/pump": {
       "version": "3.0.2",
       "resolved": "https://registry.npmmirror.com/pump/-/pump-3.0.2.tgz",
       "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
-      "dev": true,
-      "optional": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -9297,6 +9641,44 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/puppeteer": {
+      "version": "23.8.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-23.8.0.tgz",
+      "integrity": "sha512-MFWDMWoCcOpwNwQIjA9gPKWrEUbj8bLCzkK56w5lZPMUT6wK4FfpgOEPxKffVmXEMYMZzgcjxzqy15b/Q1ibaw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.4.1",
+        "chromium-bidi": "0.8.0",
+        "cosmiconfig": "^9.0.0",
+        "devtools-protocol": "0.0.1367902",
+        "puppeteer-core": "23.8.0",
+        "typed-query-selector": "^2.12.0"
+      },
+      "bin": {
+        "puppeteer": "lib/cjs/puppeteer/node/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "23.8.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-23.8.0.tgz",
+      "integrity": "sha512-c2ymGN2M//We7pC+JhP2dE/g4+qnT89BO+EMSZyJmecN3DN6RNqErA7eH7DrWoNIcU75r2nP4VHa4pswAL6NVg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.4.1",
+        "chromium-bidi": "0.8.0",
+        "debug": "^4.3.7",
+        "devtools-protocol": "0.0.1367902",
+        "typed-query-selector": "^2.12.0",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/qs": {
@@ -9333,6 +9715,12 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/queue-tick": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
+      "license": "MIT"
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -9475,7 +9863,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmmirror.com/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9484,7 +9871,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmmirror.com/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -9845,7 +10231,6 @@
       "version": "7.6.3",
       "resolved": "https://registry.npmmirror.com/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -10131,11 +10516,49 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^9.0.5",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.4.tgz",
+      "integrity": "sha512-GNAq/eg8Udq2x0eNiFkr9gRg5bA7PXEWagQdeRX4cPSG+X/8V38v637gim9bjFptMk1QWsCTr0ttrJEiXbNnRw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.1",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmmirror.com/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10187,6 +10610,12 @@
         "through2": "~2.0.0"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/stdin-discarder": {
       "version": "0.1.0",
       "resolved": "https://registry.npmmirror.com/stdin-discarder/-/stdin-discarder-0.1.0.tgz",
@@ -10220,6 +10649,20 @@
       "dependencies": {
         "duplexer2": "~0.1.0",
         "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.20.2",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.20.2.tgz",
+      "integrity": "sha512-aDGDLU+j9tJcUdPGOaHmVF1u/hhI+CsGkT02V3OKlHDV7IukOI+nTWAGkiZEKCO35rWN1wIr4tS7YFr1f4qSvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-fifo": "^1.3.2",
+        "queue-tick": "^1.0.1",
+        "text-decoder": "^1.1.0"
+      },
+      "optionalDependencies": {
+        "bare-events": "^2.2.0"
       }
     },
     "node_modules/string_decoder": {
@@ -10300,7 +10743,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmmirror.com/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -10606,6 +11048,12 @@
         "node": "*"
       }
     },
+    "node_modules/text-decoder": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.1.tgz",
+      "integrity": "sha512-x9v3H/lTKIJKQQe7RPQkLfKAnc9lUTkWDypIQgTzPJAq+5/GCDHonmshfvlsNSj58yyshbIJJDLmU15qNERrXQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmmirror.com/text-table/-/text-table-0.2.0.tgz",
@@ -10632,6 +11080,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "license": "MIT"
     },
     "node_modules/through2": {
       "version": "2.0.5",
@@ -10706,8 +11160,7 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
@@ -10755,6 +11208,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
+      "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
+      "license": "MIT"
+    },
     "node_modules/typed-rest-client": {
       "version": "1.8.11",
       "resolved": "https://registry.npmmirror.com/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
@@ -10767,10 +11226,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmmirror.com/typescript/-/typescript-5.6.2.tgz",
-      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
-      "dev": true,
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10798,6 +11258,40 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/unbzip2-stream": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
+      }
+    },
+    "node_modules/unbzip2-stream/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "node_modules/underscore": {
       "version": "1.13.7",
       "resolved": "https://registry.npmmirror.com/underscore/-/underscore-1.13.7.tgz",
@@ -10816,8 +11310,7 @@
     "node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmmirror.com/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
     },
     "node_modules/unicode-emoji-modifier-base": {
       "version": "1.0.0",
@@ -10865,7 +11358,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmmirror.com/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -10884,6 +11376,12 @@
       "resolved": "https://registry.npmmirror.com/url-join/-/url-join-4.0.1.tgz",
       "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
       "dev": true
+    },
+    "node_modules/urlpattern-polyfill": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+      "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
+      "license": "MIT"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -11078,8 +11576,28 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmmirror.com/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xml2js": {
       "version": "0.5.0",
@@ -11116,7 +11634,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmmirror.com/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -11131,7 +11648,6 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmmirror.com/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -11149,7 +11665,6 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmmirror.com/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -11172,14 +11687,12 @@
     "node_modules/yargs/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmmirror.com/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/yargs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmmirror.com/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -11193,7 +11706,6 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmmirror.com/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "dev": true,
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
@@ -11230,6 +11742,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@types/puppeteer": "^5.4.7",
         "nanoid": "^3.3.7",
-        "puppeteer": "^23.8.0"
+        "puppeteer": "^23.8.0",
+        "vectordb": "^0.12.0"
       },
       "devDependencies": {
         "@semantic-release/changelog": "^6.0.3",
@@ -34,6 +35,56 @@
       "engines": {
         "vscode": "^1.93.0"
       }
+    },
+    "node_modules/@75lb/deep-merge": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@75lb/deep-merge/-/deep-merge-1.1.2.tgz",
+      "integrity": "sha512-08K9ou5VNbheZFxM5tDWoqjA3ImC50DiuuJ2tj1yEPRfkp8lLLg6XAaJ4On+a0yAXor/8ay5gHnAIshRM44Kpw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "typical": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/@75lb/deep-merge/node_modules/typical": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/@apache-arrow/ts": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/@apache-arrow/ts/-/ts-14.0.2.tgz",
+      "integrity": "sha512-CtwAvLkK0CZv7xsYeCo91ml6PvlfzAmAJZkRYuz2GNBwfYufj5SVi0iuSMwIMkcU/szVwvLdzORSLa5PlF/2ug==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@types/command-line-args": "5.2.0",
+        "@types/command-line-usage": "5.0.2",
+        "@types/node": "20.3.0",
+        "@types/pad-left": "2.1.1",
+        "command-line-args": "5.2.1",
+        "command-line-usage": "7.0.1",
+        "flatbuffers": "23.5.26",
+        "json-bignum": "^0.0.3",
+        "pad-left": "^2.1.0",
+        "tslib": "^2.5.3"
+      }
+    },
+    "node_modules/@apache-arrow/ts/node_modules/@types/node": {
+      "version": "20.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.0.tgz",
+      "integrity": "sha512-cumHmIAf6On83X7yP+LrsEyUOf/YlociZelmpRYaGFydoaPdxdt80MAbu6vWerQT2COCp2nPvHdsbD7tHn/YlQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@azure/abort-controller": {
       "version": "2.1.2",
@@ -479,6 +530,77 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@lancedb/vectordb-darwin-arm64": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/vectordb-darwin-arm64/-/vectordb-darwin-arm64-0.12.0.tgz",
+      "integrity": "sha512-9X6UyP/ozHkv39YZ8DWh82m3aeQmUtrVDNuRe3o8has6dJyD/qPYukI8Zked4q8J+86/lgQbr4f+WW2V4Dfc1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@lancedb/vectordb-darwin-x64": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/vectordb-darwin-x64/-/vectordb-darwin-x64-0.12.0.tgz",
+      "integrity": "sha512-zG+//P3BBpmOiLR+dop68T9AFNxazWlSLF8yVdAtvsqjRzcrrMLR//rIrRcbPHxu8gvvLrMDoDZT+AHd2rElyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@lancedb/vectordb-linux-arm64-gnu": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/vectordb-linux-arm64-gnu/-/vectordb-linux-arm64-gnu-0.12.0.tgz",
+      "integrity": "sha512-5RiJkcZEdMkK5WUfkV+HVFnJaAergfSiLNgUwJaovEEX8yVChkhrdZFSUj1o/k2k6Ix9mQq+xfIUF+aGN/XnDQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lancedb/vectordb-linux-x64-gnu": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/vectordb-linux-x64-gnu/-/vectordb-linux-x64-gnu-0.12.0.tgz",
+      "integrity": "sha512-JFulRNBHLF0TyE0tThaAB9T7CM3zLquPsBF6oA9b1stVdXbEqVqLMltjem0tqfj30zEoEbAKDPpEKII4CPQMTA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lancedb/vectordb-win32-x64-msvc": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/vectordb-win32-x64-msvc/-/vectordb-win32-x64-msvc-0.12.0.tgz",
+      "integrity": "sha512-T3s/RzB5dvXBqU3qmS6zyHhF0RHS2sSs81zKzYQy2R2nEVPbnwutFSsdA1wEqEXZlr8uTD9nLbkKJKqRNTXVEg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@neon-rs/load": {
+      "version": "0.0.74",
+      "resolved": "https://registry.npmjs.org/@neon-rs/load/-/load-0.0.74.tgz",
+      "integrity": "sha512-/cPZD907UNz55yrc/ud4wDgQKtU1TvkD9jeqZWG6J4IMmZkp6zgjkQcKA8UvpkZlcpPHvc8J17sGzLFbP/LUYg==",
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1268,6 +1390,20 @@
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
       "license": "MIT"
     },
+    "node_modules/@types/command-line-args": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.0.tgz",
+      "integrity": "sha512-UuKzKpJJ/Ief6ufIaIzr3A/0XnluX7RvFgwkV89Yzvm77wCh1kFaFmqN8XEnGcN62EuHdedQjEMb8mYxFLGPyA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/command-line-usage": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.2.tgz",
+      "integrity": "sha512-n7RlEEJ+4x4TS7ZQddTmNSxP+zziEG0TNsMfiRIxcIVXt71ENJ9ojeXmGO3wPoTdn7pJcU2xc3CJYMktNT6DPg==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmmirror.com/@types/estree/-/estree-1.0.6.tgz",
@@ -1306,6 +1442,13 @@
       "resolved": "https://registry.npmmirror.com/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true
+    },
+    "node_modules/@types/pad-left": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/pad-left/-/pad-left-2.1.1.tgz",
+      "integrity": "sha512-Xd22WCRBydkGSApl5Bw0PhAOHKSVjNL3E3AwzKaps96IMraPqy5BvZIsBVK6JLwdybUzjHnuWVwpDd0JjTfHXA==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/puppeteer": {
       "version": "5.4.7",
@@ -2034,6 +2177,35 @@
         "node": ">= 8"
       }
     },
+    "node_modules/apache-arrow": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-14.0.2.tgz",
+      "integrity": "sha512-EBO2xJN36/XoY81nhLcwCJgFwkboDZeyNQ+OPsG7bCoQjc2BT0aTyH/MR6SrL+LirSNz+cYqjGRlupMMlP1aEg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@types/command-line-args": "5.2.0",
+        "@types/command-line-usage": "5.0.2",
+        "@types/node": "20.3.0",
+        "@types/pad-left": "2.1.1",
+        "command-line-args": "5.2.1",
+        "command-line-usage": "7.0.1",
+        "flatbuffers": "23.5.26",
+        "json-bignum": "^0.0.3",
+        "pad-left": "^2.1.0",
+        "tslib": "^2.5.3"
+      },
+      "bin": {
+        "arrow2csv": "bin/arrow2csv.js"
+      }
+    },
+    "node_modules/apache-arrow/node_modules/@types/node": {
+      "version": "20.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.0.tgz",
+      "integrity": "sha512-cumHmIAf6On83X7yP+LrsEyUOf/YlociZelmpRYaGFydoaPdxdt80MAbu6vWerQT2COCp2nPvHdsbD7tHn/YlQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmmirror.com/argparse/-/argparse-2.0.1.tgz",
@@ -2044,6 +2216,16 @@
       "resolved": "https://registry.npmmirror.com/argv-formatter/-/argv-formatter-1.0.0.tgz",
       "integrity": "sha512-F2+Hkm9xFaRg+GkaNnbwXNDV5O6pnCFEmqyhvfC/Ic5LbgOWjJh3L+mN/s91rxVL3znE7DYVpW0GJFT+4YBgWw==",
       "dev": true
+    },
+    "node_modules/array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/array-ify": {
       "version": "1.0.0",
@@ -2066,8 +2248,18 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmmirror.com/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "node_modules/azure-devops-node-api": {
       "version": "12.5.0",
@@ -2353,7 +2545,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmmirror.com/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2365,11 +2556,26 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
     "node_modules/chalk/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmmirror.com/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -2737,12 +2943,63 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmmirror.com/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/command-line-args": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
+      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "array-back": "^3.1.0",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.1.tgz",
+      "integrity": "sha512-NCyznE//MuTjwi3y84QVUGEOT+P5oto1e1Pk/jFPVdPPfsG03qpTIl3yw6etR+v73d0lXsoojRpvbru2sqePxQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "chalk-template": "^0.4.0",
+        "table-layout": "^3.0.0",
+        "typical": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/array-back": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
+      "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/typical": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.17"
       }
     },
     "node_modules/commander": {
@@ -3083,7 +3340,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmmirror.com/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -3908,6 +4164,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "array-back": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmmirror.com/find-up/-/find-up-5.0.0.tgz",
@@ -3974,11 +4243,38 @@
         "node": ">=16"
       }
     },
+    "node_modules/flatbuffers": {
+      "version": "23.5.26",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-23.5.26.tgz",
+      "integrity": "sha512-vE+SI9vrJDwi1oETtTIFldC/o9GsVKRM+s6EL0nQgxXlYV1Vc4Tk30hj4xGICftInKQKj1F3up2n8UbIVobISQ==",
+      "license": "SEE LICENSE IN LICENSE",
+      "peer": true
+    },
     "node_modules/flatted": {
       "version": "3.3.1",
       "resolved": "https://registry.npmmirror.com/flatted/-/flatted-3.3.1.tgz",
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/foreground-child": {
       "version": "3.3.0",
@@ -4000,7 +4296,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmmirror.com/form-data/-/form-data-4.0.1.tgz",
       "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -4280,7 +4575,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmmirror.com/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -4878,6 +5172,15 @@
       "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
       "license": "MIT"
     },
+    "node_modules/json-bignum": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
+      "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmmirror.com/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -5112,14 +5415,20 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmmirror.com/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",
       "resolved": "https://registry.npmmirror.com/lodash-es/-/lodash-es-4.17.21.tgz",
       "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
       "dev": true
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.capitalize": {
       "version": "4.2.1",
@@ -5360,7 +5669,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmmirror.com/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -5369,7 +5677,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmmirror.com/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -9240,6 +9547,19 @@
       "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
       "dev": true
     },
+    "node_modules/pad-left": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pad-left/-/pad-left-2.1.0.tgz",
+      "integrity": "sha512-HJxs9K9AztdIQIAIa/OIazRAUW/L6B9hbQDxO4X07roW3eo9XqZc2ur9bn1StH9CnbbI9EgvejHQX7CBpCF1QA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "repeat-string": "^1.5.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmmirror.com/pako/-/pako-1.0.11.tgz",
@@ -9857,6 +10177,16 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/require-directory": {
@@ -10651,6 +10981,16 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "node_modules/stream-read-all": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/stream-read-all/-/stream-read-all-3.0.1.tgz",
+      "integrity": "sha512-EWZT9XOceBPlVJRrYcykW8jyRSZYbkb/0ZK36uLEmoWVO5gxBOnntNTseNzfREsqxqdfEGQrD8SXQ3QWbBmq8A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/streamx": {
       "version": "2.20.2",
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.20.2.tgz",
@@ -10847,6 +11187,48 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/table-layout": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-3.0.2.tgz",
+      "integrity": "sha512-rpyNZYRw+/C+dYkcQ3Pr+rLxW4CfHpXjPDnG7lYhdRoUcZTUt+KEsX+94RGp/aVp/MQU35JCITv2T/beY4m+hw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@75lb/deep-merge": "^1.1.1",
+        "array-back": "^6.2.2",
+        "command-line-args": "^5.2.1",
+        "command-line-usage": "^7.0.0",
+        "stream-read-all": "^3.0.1",
+        "typical": "^7.1.1",
+        "wordwrapjs": "^5.1.0"
+      },
+      "bin": {
+        "table-layout": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/table-layout/node_modules/array-back": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
+      "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/table-layout/node_modules/typical": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.17"
       }
     },
     "node_modules/tapable": {
@@ -11239,6 +11621,16 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/uc.micro": {
       "version": "2.1.0",
       "resolved": "https://registry.npmmirror.com/uc.micro/-/uc.micro-2.1.0.tgz",
@@ -11422,6 +11814,36 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "node_modules/vectordb": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/vectordb/-/vectordb-0.12.0.tgz",
+      "integrity": "sha512-Dp4hpP3DpDGzzV+1uYpH/6EI2hgcV+zyBLesKNwPdZct8kv8ZzCFTHhP/IARdfovoKB/8b4fczwfWKb1SIfCQw==",
+      "cpu": [
+        "x64",
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "dependencies": {
+        "@neon-rs/load": "^0.0.74",
+        "axios": "^1.4.0"
+      },
+      "optionalDependencies": {
+        "@lancedb/vectordb-darwin-arm64": "0.12.0",
+        "@lancedb/vectordb-darwin-x64": "0.12.0",
+        "@lancedb/vectordb-linux-arm64-gnu": "0.12.0",
+        "@lancedb/vectordb-linux-x64-gnu": "0.12.0",
+        "@lancedb/vectordb-win32-x64-msvc": "0.12.0"
+      },
+      "peerDependencies": {
+        "@apache-arrow/ts": "^14.0.2",
+        "apache-arrow": "^14.0.2"
+      }
+    },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
       "resolved": "https://registry.npmmirror.com/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
@@ -11472,6 +11894,16 @@
       "resolved": "https://registry.npmmirror.com/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "dev": true
+    },
+    "node_modules/wordwrapjs": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.0.tgz",
+      "integrity": "sha512-JNjcULU2e4KJwUNv6CHgI46UvDGitb6dGryHajXTDiLgg1/RiGoPSDw4kZfYnwGtEXf2ZMeIewDQgFGzkCB2Sg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.17"
+      }
     },
     "node_modules/workerpool": {
       "version": "6.5.1",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,8 @@
   "dependencies": {
     "@types/puppeteer": "^5.4.7",
     "nanoid": "^3.3.7",
-    "puppeteer": "^23.8.0"
+    "puppeteer": "^23.8.0",
+    "vectordb": "^0.12.0"
   },
   "release": {
     "branches": [

--- a/package.json
+++ b/package.json
@@ -114,8 +114,8 @@
     "@semantic-release/exec": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@types/mocha": "^10.0.7",
-    "@types/node": "20.x",
-    "@types/vscode": "^1.93.0",
+    "@types/node": "^20.17.6",
+    "@types/vscode": "^1.95.0",
     "@typescript-eslint/eslint-plugin": "^8.3.0",
     "@typescript-eslint/parser": "^8.3.0",
     "@vscode/test-cli": "^0.0.10",
@@ -125,10 +125,12 @@
     "eslint": "^9.9.1",
     "prettier": "^3.3.3",
     "semantic-release": "^24.2.0",
-    "typescript": "^5.5.4"
+    "typescript": "^5.6.3"
   },
   "dependencies": {
-    "nanoid": "^3.3.7"
+    "@types/puppeteer": "^5.4.7",
+    "nanoid": "^3.3.7",
+    "puppeteer": "^23.8.0"
   },
   "release": {
     "branches": [

--- a/src/docs/DocsCrawler.ts
+++ b/src/docs/DocsCrawler.ts
@@ -1,0 +1,74 @@
+import { DefaultCrawler } from './crawlers/DefaultCrawler';
+import { CheerioCrawler } from './crawlers/CheerioCrawler';
+import { ChromiumCrawler } from './crawlers/ChromiumCrawler';
+import { PageData } from './crawlers/BaseCrawler';
+
+export class DocsCrawler {
+    private readonly MAX_REQUESTS_PER_CRAWL = 1000;
+    private readonly GITHUB_HOST = 'github.com';
+
+    constructor(private chromiumInstaller: { 
+        shouldProposeUseChromium: () => boolean;
+        proposeAndAttemptInstall: (url: string) => Promise<boolean>;
+    }) {}
+
+    async *crawl(
+        startUrl: URL,
+        maxRequestsPerCrawl: number = this.MAX_REQUESTS_PER_CRAWL,
+    ): AsyncGenerator<PageData> {
+        if (startUrl.host === this.GITHUB_HOST) {
+            // GitHub docs require special handling
+            yield* new ChromiumCrawler(startUrl, maxRequestsPerCrawl).crawl();
+            return;
+        }
+
+        try {
+            // Try the simple crawler first
+            yield* new DefaultCrawler(startUrl, maxRequestsPerCrawl).crawl();
+            return;
+        } catch (e) {
+            console.error("Default crawler failed, trying backup: ", e);
+        }
+
+        try {
+            // Try Cheerio crawler next
+            let didCrawlSinglePage = false;
+
+            for await (const pageData of new CheerioCrawler(
+                startUrl,
+                maxRequestsPerCrawl,
+            ).crawl()) {
+                yield pageData;
+                didCrawlSinglePage = true;
+            }
+
+            if (didCrawlSinglePage) {
+                return;
+            }
+        } catch (e) {
+            console.error("Cheerio crawler failed, trying Chromium: ", e);
+        }
+
+        // If both simple crawlers failed, try Chromium
+        const shouldProposeUseChromium = this.chromiumInstaller.shouldProposeUseChromium();
+
+        if (shouldProposeUseChromium) {
+            const didInstall = await this.chromiumInstaller.proposeAndAttemptInstall(
+                startUrl.toString(),
+            );
+
+            if (didInstall) {
+                console.log(`Successfully installed Chromium! Retrying crawl of: ${startUrl.toString()}`);
+                yield* new ChromiumCrawler(startUrl, maxRequestsPerCrawl).crawl();
+            }
+        } else {
+            // If we shouldn't propose Chromium, try it anyway if it's already installed
+            try {
+                yield* new ChromiumCrawler(startUrl, maxRequestsPerCrawl).crawl();
+            } catch (e) {
+                console.error("All crawlers failed: ", e);
+                throw new Error(`Failed to crawl ${startUrl.toString()} with all available crawlers`);
+            }
+        }
+    }
+}

--- a/src/docs/DocsService.ts
+++ b/src/docs/DocsService.ts
@@ -1,0 +1,218 @@
+import { DocsCrawler } from './DocsCrawler';
+import { DocsConfig } from '../types';
+
+interface Article {
+    title: string;
+    content: string;
+    subpath: string;
+    url: string;
+}
+
+interface Chunk {
+    content: string;
+    article: Article;
+}
+
+interface IndexingProgressUpdate {
+    progress: number;
+    desc: string;
+    status: 'indexing' | 'done' | 'failed';
+}
+
+interface EmbeddingsProvider {
+    maxChunkSize: number;
+    embed: (texts: string[]) => Promise<number[][]>;
+}
+
+export class DocsService {
+    private docsIndexingQueue = new Set<string>();
+
+    constructor(
+        private docsCrawler: DocsCrawler,
+        private embeddingsProvider: EmbeddingsProvider,
+        private storage: {
+            has: (key: string) => Promise<boolean>;
+            delete: (key: string) => Promise<void>;
+            add: (data: {
+                siteIndexingConfig: DocsConfig;
+                chunks: Chunk[];
+                embeddings: number[][];
+                favicon?: string;
+            }) => Promise<void>;
+        }
+    ) {}
+
+    async *indexSite(
+        siteIndexingConfig: DocsConfig,
+        reIndex: boolean = false,
+    ): AsyncGenerator<IndexingProgressUpdate> {
+        const { startUrl } = siteIndexingConfig;
+
+        if (this.docsIndexingQueue.has(startUrl)) {
+            console.log("Already in queue");
+            return;
+        }
+
+        if (!reIndex && (await this.storage.has(startUrl))) {
+            yield {
+                progress: 1,
+                desc: "Already indexed",
+                status: "done",
+            };
+            return;
+        }
+
+        // Mark the site as currently being indexed
+        this.docsIndexingQueue.add(startUrl);
+
+        yield {
+            progress: 0,
+            desc: "Finding subpages",
+            status: "indexing",
+        };
+
+        const articles: Article[] = [];
+        let processedPages = 0;
+        let maxKnownPages = 1;
+
+        try {
+            // Crawl pages and retrieve info as articles
+            for await (const page of this.docsCrawler.crawl(new URL(startUrl))) {
+                processedPages++;
+
+                const article = {
+                    title: page.title,
+                    content: page.content,
+                    subpath: page.path,
+                    url: page.url,
+                };
+
+                articles.push(article);
+
+                // Use a heuristic approach for progress calculation
+                const progress = Math.min(processedPages / maxKnownPages, 1);
+
+                yield {
+                    progress,
+                    desc: `Finding subpages (${page.path})`,
+                    status: "indexing",
+                };
+
+                // Increase maxKnownPages to delay progress reaching 100% too soon
+                if (processedPages === maxKnownPages) {
+                    maxKnownPages *= 2;
+                }
+            }
+
+            const chunks: Chunk[] = [];
+            const embeddings: number[][] = [];
+
+            // Create embeddings of retrieved articles
+            console.log(`Creating embeddings for ${articles.length} articles`);
+
+            for (let i = 0; i < articles.length; i++) {
+                const article = articles[i];
+                yield {
+                    progress: i / articles.length,
+                    desc: `Creating Embeddings: ${article.subpath}`,
+                    status: "indexing",
+                };
+
+                try {
+                    const articleChunks = this.chunkArticle(
+                        article,
+                        this.embeddingsProvider.maxChunkSize,
+                    );
+
+                    const chunkContents = articleChunks.map(
+                        (chunk) => chunk.content,
+                    );
+
+                    chunks.push(...articleChunks);
+
+                    const chunkEmbeddings = await this.embeddingsProvider.embed(
+                        chunkContents,
+                    );
+
+                    embeddings.push(...chunkEmbeddings);
+                } catch (e) {
+                    console.warn("Error chunking article: ", e);
+                }
+            }
+
+            if (embeddings.length === 0) {
+                console.error(
+                    `No embeddings were created for site: ${siteIndexingConfig.startUrl}\n Num chunks: ${chunks.length}`,
+                );
+
+                yield {
+                    progress: 1,
+                    desc: `No embeddings were created for site: ${siteIndexingConfig.startUrl}`,
+                    status: "failed",
+                };
+
+                return;
+            }
+
+            // Add docs to storage
+            console.log(`Adding ${embeddings.length} embeddings to storage`);
+
+            yield {
+                progress: 0.9,
+                desc: `Adding ${embeddings.length} embeddings to storage`,
+                status: "indexing",
+            };
+
+            // Delete indexed docs if re-indexing
+            if (reIndex && (await this.storage.has(startUrl))) {
+                console.log("Deleting old embeddings");
+                await this.storage.delete(startUrl);
+            }
+
+            await this.storage.add({
+                siteIndexingConfig,
+                chunks,
+                embeddings,
+            });
+
+            yield {
+                progress: 1,
+                desc: "Done",
+                status: "done",
+            };
+
+            console.log(`Successfully indexed: ${siteIndexingConfig.startUrl}`);
+        } finally {
+            this.docsIndexingQueue.delete(startUrl);
+        }
+    }
+
+    private chunkArticle(article: Article, maxChunkSize: number): Chunk[] {
+        const chunks: Chunk[] = [];
+        const words = article.content.split(/\s+/);
+        let currentChunk: string[] = [];
+        let currentSize = 0;
+
+        for (const word of words) {
+            if (currentSize + word.length > maxChunkSize && currentChunk.length > 0) {
+                chunks.push({
+                    content: currentChunk.join(' '),
+                    article,
+                });
+                currentChunk = [];
+                currentSize = 0;
+            }
+            currentChunk.push(word);
+            currentSize += word.length + 1; // +1 for space
+        }
+
+        if (currentChunk.length > 0) {
+            chunks.push({
+                content: currentChunk.join(' '),
+                article,
+            });
+        }
+
+        return chunks;
+    }
+}

--- a/src/docs/crawlers/BaseCrawler.ts
+++ b/src/docs/crawlers/BaseCrawler.ts
@@ -1,0 +1,19 @@
+export interface PageData {
+    url: string;
+    path: string;
+    title: string;
+    content: string;
+}
+
+export abstract class BaseCrawler {
+    protected readonly MAX_REQUESTS_PER_CRAWL = 1000;
+    protected readonly GITHUB_HOST = 'github.com';
+
+    constructor(protected startUrl: URL) {}
+
+    abstract crawl(maxRequestsPerCrawl?: number): AsyncGenerator<PageData>;
+
+    protected isValidUrl(url: URL): boolean {
+        return url.host === this.startUrl.host;
+    }
+}

--- a/src/docs/crawlers/BaseCrawler.ts
+++ b/src/docs/crawlers/BaseCrawler.ts
@@ -9,9 +9,12 @@ export abstract class BaseCrawler {
     protected readonly MAX_REQUESTS_PER_CRAWL = 1000;
     protected readonly GITHUB_HOST = 'github.com';
 
-    constructor(protected startUrl: URL) {}
+    constructor(
+        protected startUrl: URL,
+        protected maxRequestsPerCrawl: number = 1000
+    ) {}
 
-    abstract crawl(maxRequestsPerCrawl?: number): AsyncGenerator<PageData>;
+    abstract crawl(): AsyncGenerator<PageData>;
 
     protected isValidUrl(url: URL): boolean {
         return url.host === this.startUrl.host;

--- a/src/docs/crawlers/CheerioCrawler.ts
+++ b/src/docs/crawlers/CheerioCrawler.ts
@@ -13,11 +13,11 @@ export class CheerioCrawler extends BaseCrawler {
         '#main',
     ];
 
-    async *crawl(maxRequestsPerCrawl = this.MAX_REQUESTS_PER_CRAWL): AsyncGenerator<PageData> {
+    async *crawl(): AsyncGenerator<PageData> {
         const queue: URL[] = [this.startUrl];
         let requestCount = 0;
 
-        while (queue.length > 0 && requestCount < maxRequestsPerCrawl) {
+        while (queue.length > 0 && requestCount < this.maxRequestsPerCrawl) {
             const url = queue.shift()!;
             const urlString = url.toString();
 

--- a/src/docs/crawlers/CheerioCrawler.ts
+++ b/src/docs/crawlers/CheerioCrawler.ts
@@ -1,0 +1,126 @@
+import { load } from 'cheerio';
+import { BaseCrawler, PageData } from './BaseCrawler';
+
+export class CheerioCrawler extends BaseCrawler {
+    private visited = new Set<string>();
+    private readonly contentSelectors = [
+        'article',
+        'main',
+        '.content',
+        '.documentation',
+        '.docs-content',
+        '#content',
+        '#main',
+    ];
+
+    async *crawl(maxRequestsPerCrawl = this.MAX_REQUESTS_PER_CRAWL): AsyncGenerator<PageData> {
+        const queue: URL[] = [this.startUrl];
+        let requestCount = 0;
+
+        while (queue.length > 0 && requestCount < maxRequestsPerCrawl) {
+            const url = queue.shift()!;
+            const urlString = url.toString();
+
+            if (this.visited.has(urlString)) {
+                continue;
+            }
+
+            try {
+                const response = await fetch(urlString);
+                if (!response.ok) {
+                    console.error(`Failed to fetch ${urlString}: ${response.statusText}`);
+                    continue;
+                }
+
+                const html = await response.text();
+                const $ = load(html);
+
+                // Remove non-content elements
+                $('script, style, nav, footer, header, .navigation, .sidebar, .menu, .ads').remove();
+
+                // Extract title
+                const title = $('title').text().trim() || 
+                            $('h1').first().text().trim() || 
+                            $('meta[property="og:title"]').attr('content') || 
+                            '';
+
+                // Try to find main content using common selectors
+                let content = '';
+                for (const selector of this.contentSelectors) {
+                    const element = $(selector);
+                    if (element.length > 0) {
+                        content = element.text().trim();
+                        break;
+                    }
+                }
+
+                // Fallback to body if no content found
+                if (!content) {
+                    content = $('body').text().trim();
+                }
+
+                // Clean up content
+                content = content
+                    .replace(/\s+/g, ' ')
+                    .replace(/\n+/g, '\n')
+                    .trim();
+
+                const path = url.pathname;
+
+                yield {
+                    url: urlString,
+                    path,
+                    title,
+                    content,
+                };
+
+                // Find and queue new links, focusing on documentation-like paths
+                $('a[href]').each((_, element) => {
+                    try {
+                        const href = $(element).attr('href');
+                        if (!href) return;
+
+                        // Skip anchor links and obvious non-documentation paths
+                        if (href.startsWith('#') || 
+                            href.includes('?') || 
+                            /\.(jpg|jpeg|png|gif|svg|css|js)$/i.test(href)) {
+                            return;
+                        }
+
+                        const newUrl = new URL(href, urlString);
+                        
+                        // Only follow paths that look like documentation
+                        if (this.isValidUrl(newUrl) && 
+                            this.isLikelyDocPath(newUrl.pathname) && 
+                            !this.visited.has(newUrl.toString())) {
+                            queue.push(newUrl);
+                        }
+                    } catch (error) {
+                        console.error(`Error processing link: ${error}`);
+                    }
+                });
+
+                this.visited.add(urlString);
+                requestCount++;
+            } catch (error) {
+                console.error(`Error crawling ${urlString}: ${error}`);
+                continue;
+            }
+        }
+    }
+
+    private isLikelyDocPath(path: string): boolean {
+        const docPatterns = [
+            /docs?/i,
+            /api/i,
+            /guide/i,
+            /tutorial/i,
+            /manual/i,
+            /reference/i,
+            /learn/i,
+            /getting-started/i,
+        ];
+
+        return docPatterns.some(pattern => pattern.test(path));
+    }
+}

--- a/src/docs/crawlers/ChromiumCrawler.ts
+++ b/src/docs/crawlers/ChromiumCrawler.ts
@@ -1,0 +1,134 @@
+import * as puppeteer from 'puppeteer';
+import { BaseCrawler, PageData } from './BaseCrawler';
+
+export class ChromiumCrawler extends BaseCrawler {
+    private visited = new Set<string>();
+    private browser: puppeteer.Browser | null = null;
+
+    async *crawl(maxRequestsPerCrawl = this.MAX_REQUESTS_PER_CRAWL): AsyncGenerator<PageData> {
+        try {
+            this.browser = await puppeteer.launch({
+                headless: 'new',
+                args: ['--no-sandbox', '--disable-setuid-sandbox']
+            });
+
+            const queue: URL[] = [this.startUrl];
+            let requestCount = 0;
+
+            while (queue.length > 0 && requestCount < maxRequestsPerCrawl) {
+                const url = queue.shift()!;
+                const urlString = url.toString();
+
+                if (this.visited.has(urlString)) {
+                    continue;
+                }
+
+                try {
+                    const page = await this.browser.newPage();
+                    await page.goto(urlString, {
+                        waitUntil: 'networkidle0',
+                        timeout: 30000
+                    });
+
+                    // Wait for common documentation content selectors
+                    await Promise.race([
+                        page.waitForSelector('article'),
+                        page.waitForSelector('main'),
+                        page.waitForSelector('.content'),
+                        page.waitForSelector('.documentation'),
+                        page.waitForSelector('#content'),
+                        page.waitForTimeout(5000) // Fallback timeout
+                    ]);
+
+                    // Remove non-content elements
+                    await page.evaluate(() => {
+                        const elementsToRemove = document.querySelectorAll(
+                            'script, style, nav, footer, header, .navigation, .sidebar, .menu, .ads'
+                        );
+                        elementsToRemove.forEach(el => el.remove());
+                    });
+
+                    // Extract content
+                    const data = await page.evaluate(() => {
+                        const getContent = () => {
+                            const selectors = [
+                                'article',
+                                'main',
+                                '.content',
+                                '.documentation',
+                                '#content',
+                                '#main'
+                            ];
+
+                            for (const selector of selectors) {
+                                const element = document.querySelector(selector);
+                                if (element) {
+                                    return element.textContent || '';
+                                }
+                            }
+
+                            return document.body.textContent || '';
+                        };
+
+                        return {
+                            title: document.title || document.querySelector('h1')?.textContent || '',
+                            content: getContent(),
+                            links: Array.from(document.querySelectorAll('a[href]'))
+                                .map(a => a.getAttribute('href'))
+                                .filter(href => href && !href.startsWith('#'))
+                        };
+                    });
+
+                    yield {
+                        url: urlString,
+                        path: url.pathname,
+                        title: data.title.trim(),
+                        content: data.content.replace(/\s+/g, ' ').trim()
+                    };
+
+                    // Queue new links
+                    for (const href of data.links) {
+                        try {
+                            if (!href) continue;
+                            const newUrl = new URL(href, urlString);
+                            if (this.isValidUrl(newUrl) && 
+                                this.isLikelyDocPath(newUrl.pathname) && 
+                                !this.visited.has(newUrl.toString())) {
+                                queue.push(newUrl);
+                            }
+                        } catch (error) {
+                            console.error(`Error processing link: ${error}`);
+                        }
+                    }
+
+                    await page.close();
+                    this.visited.add(urlString);
+                    requestCount++;
+                } catch (error) {
+                    console.error(`Error crawling ${urlString}: ${error}`);
+                    continue;
+                }
+            }
+        } finally {
+            if (this.browser) {
+                await this.browser.close();
+                this.browser = null;
+            }
+        }
+    }
+
+    private isLikelyDocPath(path: string): boolean {
+        const docPatterns = [
+            /docs?/i,
+            /api/i,
+            /guide/i,
+            /tutorial/i,
+            /manual/i,
+            /reference/i,
+            /learn/i,
+            /getting-started/i,
+        ];
+
+        return docPatterns.some(pattern => pattern.test(path));
+    }
+}

--- a/src/docs/crawlers/ChromiumCrawler.ts
+++ b/src/docs/crawlers/ChromiumCrawler.ts
@@ -5,17 +5,17 @@ export class ChromiumCrawler extends BaseCrawler {
     private visited = new Set<string>();
     private browser: puppeteer.Browser | null = null;
 
-    async *crawl(maxRequestsPerCrawl = this.MAX_REQUESTS_PER_CRAWL): AsyncGenerator<PageData> {
+    async *crawl(): AsyncGenerator<PageData> {
         try {
             this.browser = await puppeteer.launch({
-                headless: 'new',
+                headless: true,
                 args: ['--no-sandbox', '--disable-setuid-sandbox']
             });
 
             const queue: URL[] = [this.startUrl];
             let requestCount = 0;
 
-            while (queue.length > 0 && requestCount < maxRequestsPerCrawl) {
+            while (queue.length > 0 && requestCount < this.maxRequestsPerCrawl) {
                 const url = queue.shift()!;
                 const urlString = url.toString();
 

--- a/src/docs/crawlers/DefaultCrawler.ts
+++ b/src/docs/crawlers/DefaultCrawler.ts
@@ -4,11 +4,11 @@ import { BaseCrawler, PageData } from './BaseCrawler';
 export class DefaultCrawler extends BaseCrawler {
     private visited = new Set<string>();
 
-    async *crawl(maxRequestsPerCrawl = this.MAX_REQUESTS_PER_CRAWL): AsyncGenerator<PageData> {
+    async *crawl(): AsyncGenerator<PageData> {
         const queue: URL[] = [this.startUrl];
         let requestCount = 0;
 
-        while (queue.length > 0 && requestCount < maxRequestsPerCrawl) {
+        while (queue.length > 0 && requestCount < this.maxRequestsPerCrawl) {
             const url = queue.shift()!;
             const urlString = url.toString();
 

--- a/src/docs/crawlers/DefaultCrawler.ts
+++ b/src/docs/crawlers/DefaultCrawler.ts
@@ -1,0 +1,76 @@
+import { load } from 'cheerio';
+import { BaseCrawler, PageData } from './BaseCrawler';
+
+export class DefaultCrawler extends BaseCrawler {
+    private visited = new Set<string>();
+
+    async *crawl(maxRequestsPerCrawl = this.MAX_REQUESTS_PER_CRAWL): AsyncGenerator<PageData> {
+        const queue: URL[] = [this.startUrl];
+        let requestCount = 0;
+
+        while (queue.length > 0 && requestCount < maxRequestsPerCrawl) {
+            const url = queue.shift()!;
+            const urlString = url.toString();
+
+            if (this.visited.has(urlString)) {
+                continue;
+            }
+
+            try {
+                const response = await fetch(urlString);
+                if (!response.ok) {
+                    console.error(`Failed to fetch ${urlString}: ${response.statusText}`);
+                    continue;
+                }
+
+                const html = await response.text();
+                const $ = load(html);
+
+                // Remove script tags and comments
+                $('script').remove();
+                $('style').remove();
+                $('comments').remove();
+
+                // Extract title
+                const title = $('title').text().trim() || $('h1').first().text().trim();
+
+                // Extract main content
+                const content = $('body')
+                    .text()
+                    .replace(/\s+/g, ' ')
+                    .trim();
+
+                // Get path from URL
+                const path = url.pathname;
+
+                yield {
+                    url: urlString,
+                    path,
+                    title,
+                    content,
+                };
+
+                // Find and queue new links
+                $('a[href]').each((_, element) => {
+                    try {
+                        const href = $(element).attr('href');
+                        if (!href) return;
+
+                        const newUrl = new URL(href, urlString);
+                        if (this.isValidUrl(newUrl) && !this.visited.has(newUrl.toString())) {
+                            queue.push(newUrl);
+                        }
+                    } catch (error) {
+                        console.error(`Error processing link: ${error}`);
+                    }
+                });
+
+                this.visited.add(urlString);
+                requestCount++;
+            } catch (error) {
+                console.error(`Error crawling ${urlString}: ${error}`);
+                throw error; // Let the DocsCrawler know this crawler failed
+            }
+        }
+    }
+}

--- a/src/docs/storage/LanceDbStorage.ts
+++ b/src/docs/storage/LanceDbStorage.ts
@@ -1,0 +1,119 @@
+import { connect } from 'vectordb';
+import { DocsConfig } from '../../types';
+import { Table } from 'vectordb/table';
+
+interface LanceDbDocsRow {
+    id: string;
+    content: string;
+    embedding: number[];
+    title: string;
+    url: string;
+    starturl: string;
+    subpath: string;
+}
+
+export class LanceDbStorage {
+    private table: Table | null = null;
+    private readonly tableName = 'docs';
+
+    constructor(private dbPath: string) {}
+
+    private async getOrCreateTable(initializationVector: number[]): Promise<Table> {
+        if (this.table) {
+            return this.table;
+        }
+
+        const db = await connect(this.dbPath);
+        
+        try {
+            this.table = await db.openTable(this.tableName);
+        } catch {
+            // Table doesn't exist, create it
+            this.table = await db.createTable(this.tableName, [{
+                id: 'init',
+                content: '',
+                embedding: initializationVector,
+                title: '',
+                url: '',
+                starturl: '',
+                subpath: '',
+            }]);
+        }
+
+        return this.table;
+    }
+
+    async has(startUrl: string): Promise<boolean> {
+        const table = await this.getOrCreateTable([0]); // Dummy vector for initialization
+        const result = await table
+            .search([0])
+            .where(`starturl = '${startUrl}'`)
+            .limit(1)
+            .execute();
+        return result.length > 0;
+    }
+
+    async delete(startUrl: string): Promise<void> {
+        const table = await this.getOrCreateTable([0]); // Dummy vector for initialization
+        await table.delete().where(`starturl = '${startUrl}'`).execute();
+    }
+
+    async add(data: {
+        siteIndexingConfig: DocsConfig;
+        chunks: Array<{
+            content: string;
+            article: {
+                title: string;
+                url: string;
+                subpath: string;
+            };
+        }>;
+        embeddings: number[][];
+    }): Promise<void> {
+        const { siteIndexingConfig, chunks, embeddings } = data;
+        
+        if (chunks.length !== embeddings.length) {
+            throw new Error('Chunks and embeddings length mismatch');
+        }
+
+        const rows: LanceDbDocsRow[] = chunks.map((chunk, i) => ({
+            id: `${siteIndexingConfig.startUrl}-${i}`,
+            content: chunk.content,
+            embedding: embeddings[i],
+            title: chunk.article.title,
+            url: chunk.article.url,
+            starturl: siteIndexingConfig.startUrl,
+            subpath: chunk.article.subpath,
+        }));
+
+        const table = await this.getOrCreateTable(embeddings[0]);
+        await table.add(rows);
+    }
+
+    async search(
+        vector: number[],
+        startUrl: string,
+        limit: number = 5
+    ): Promise<Array<{
+        content: string;
+        title: string;
+        url: string;
+        subpath: string;
+        score: number;
+    }>> {
+        const table = await this.getOrCreateTable(vector);
+        const results = await table
+            .search(vector)
+            .where(`starturl = '${startUrl}'`)
+            .limit(limit)
+            .execute();
+
+        return results.map(result => ({
+            content: result.content,
+            title: result.title,
+            url: result.url,
+            subpath: result.subpath,
+            score: result.score,
+        }));
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,144 +1,94 @@
 import * as vscode from 'vscode';
-import VscodeReactView from './webViewProvider';
-import { DiffContentProviderId } from './types';
-import AiderChatService from './aiderChatService';
-
-let outputChannel: vscode.LogOutputChannel;
-
-// 添加一个新的 TextDocumentContentProvider 类
-class DiffContentProvider implements vscode.TextDocumentContentProvider {
-  provideTextDocumentContent(uri: vscode.Uri): string {
-    return Buffer.from(uri.query, 'base64').toString('utf-8');
-  }
-}
-
-let aiderChatService: AiderChatService | undefined;
+import WebviewProvider from './webViewProvider';
+import { DocsConfig } from './types';
 
 export function activate(context: vscode.ExtensionContext) {
-  outputChannel = vscode.window.createOutputChannel('Aider Composer', {
-    log: true,
-  });
-  outputChannel.info('Extension "aider-composer" is now active!');
+    const outputChannel = vscode.window.createOutputChannel('Aider Composer', { log: true });
+    const provider = new WebviewProvider(context, outputChannel);
 
-  const webviewProvider = new VscodeReactView(context, outputChannel);
-
-  context.subscriptions.push(
-    vscode.window.registerWebviewViewProvider(
-      VscodeReactView.viewType,
-      webviewProvider,
-      { webviewOptions: { retainContextWhenHidden: true } },
-    ),
-  );
-
-  // diff content provider
-  const diffProvider = new DiffContentProvider();
-  const providerRegistration =
-    vscode.workspace.registerTextDocumentContentProvider(
-      DiffContentProviderId,
-      diffProvider,
+    context.subscriptions.push(
+        vscode.window.registerWebviewViewProvider(
+            WebviewProvider.viewType,
+            provider,
+        ),
     );
-  context.subscriptions.push(providerRegistration);
 
-  // add button click
-  context.subscriptions.push(
-    vscode.commands.registerCommand('aider-composer.AddButtonClick', () => {
-      outputChannel.info('Add button clicked!');
-      webviewProvider.newChat();
-    }),
-  );
+    // Add command to configure docs providers
+    context.subscriptions.push(
+        vscode.commands.registerCommand('aider-composer.configureDocs', async () => {
+            const config = vscode.workspace.getConfiguration('aider-composer');
+            const currentProviders = config.get<DocsConfig[]>('docsProviders', []);
 
-  // setting button click
-  context.subscriptions.push(
-    vscode.commands.registerCommand('aider-composer.SettingButtonClick', () => {
-      outputChannel.info('Setting button clicked!');
-      webviewProvider.setViewType('setting');
-    }),
-  );
+            const title = await vscode.window.showInputBox({
+                prompt: 'Enter documentation title',
+                placeHolder: 'e.g., React Documentation'
+            });
+            if (!title) return;
 
-  // history button click
-  context.subscriptions.push(
-    vscode.commands.registerCommand('aider-composer.HistoryButtonClick', () => {
-      outputChannel.info('History button clicked!');
-      webviewProvider.setViewType('history');
-    }),
-  );
+            const startUrl = await vscode.window.showInputBox({
+                prompt: 'Enter documentation start URL',
+                placeHolder: 'e.g., https://react.dev/reference/react'
+            });
+            if (!startUrl) return;
 
-  // confirm modify
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      'aider-composer.ConfirmModify',
-      async (uri: vscode.Uri, group: unknown) => {
-        outputChannel.info(`ConfirmModify: ${uri.path}`);
+            const rootUrl = await vscode.window.showInputBox({
+                prompt: 'Enter documentation root URL',
+                placeHolder: 'e.g., https://react.dev'
+            });
+            if (!rootUrl) return;
 
-        const modifiedContent = Buffer.from(uri.query, 'base64');
-        const fileUri = vscode.Uri.file(uri.path);
+            const faviconUrl = await vscode.window.showInputBox({
+                prompt: 'Enter favicon URL (optional)',
+                placeHolder: 'e.g., https://react.dev/favicon.ico'
+            });
 
-        try {
-          await vscode.workspace.fs.writeFile(fileUri, modifiedContent);
-        } catch (error) {
-          vscode.window.showErrorMessage(`Error writing file: ${error}`);
-          outputChannel.error(`Error writing file: ${error}`);
-        }
+            const newProvider: DocsConfig = {
+                title,
+                startUrl,
+                rootUrl,
+                faviconUrl: faviconUrl || undefined
+            };
 
-        await vscode.commands.executeCommand(
-          'workbench.action.closeActiveEditor',
-        );
+            await config.update(
+                'docsProviders',
+                [...currentProviders, newProvider],
+                vscode.ConfigurationTarget.Global
+            );
 
-        vscode.window.showInformationMessage(
-          `path: ${uri.path} modified content is written`,
-        );
-      },
-    ),
-  );
-
-  // current editor changed
-  context.subscriptions.push(
-    vscode.window.onDidChangeActiveTextEditor((editor) => {
-      if (!editor) {
-        return;
-      }
-
-      webviewProvider.currentEditorChanged(editor);
-    }),
-  );
-
-  const aiderChatService = new AiderChatService(context, outputChannel);
-
-  aiderChatService.onStarted = () => {
-    vscode.commands.executeCommand(
-      'setContext',
-      'aider-composer.Started',
-      true,
+            vscode.window.showInformationMessage(`Added documentation provider: ${title}`);
+        })
     );
-    webviewProvider.serverStarted(`http://127.0.0.1:${aiderChatService.port}`);
-    const activeEditor = vscode.window.activeTextEditor;
-    if (activeEditor) {
-      webviewProvider.currentEditorChanged(activeEditor);
-    }
-  };
 
-  // Add configuration change listener
-  context.subscriptions.push(
-    vscode.workspace.onDidChangeConfiguration((event) => {
-      // Check if our extension's config was changed
-      if (event.affectsConfiguration('aider-composer')) {
-        if (event.affectsConfiguration('aider-composer.pythonPath')) {
-          const config = vscode.workspace.getConfiguration('aider-composer');
-          const newPythonPath = config.get('pythonPath');
-          outputChannel.debug(`Python path changed to: ${newPythonPath}`);
+    // Add command to start docs indexing
+    context.subscriptions.push(
+        vscode.commands.registerCommand('aider-composer.indexDocs', async () => {
+            const config = vscode.workspace.getConfiguration('aider-composer');
+            const providers = config.get<DocsConfig[]>('docsProviders', []);
 
-          aiderChatService.restart();
-        }
-      }
-    }),
-  );
+            if (providers.length === 0) {
+                vscode.window.showWarningMessage('No documentation providers configured. Use the "Configure Docs Provider" command first.');
+                return;
+            }
 
-  aiderChatService.start();
+            const selected = await vscode.window.showQuickPick(
+                providers.map(p => p.title),
+                {
+                    placeHolder: 'Select documentation to index'
+                }
+            );
 
-  outputChannel.show();
+            if (selected) {
+                const provider = providers.find(p => p.title === selected);
+                if (provider) {
+                    // TODO: Implement actual indexing
+                    vscode.window.showInformationMessage(`Started indexing: ${provider.title}`);
+                }
+            }
+        })
+    );
+
+    // Add the output channel to subscriptions for cleanup
+    context.subscriptions.push(outputChannel);
 }
 
-export function deactivate() {
-  outputChannel.info('Extension "aider-composer" is now deactive!');
-  aiderChatService?.stop();
-}
+export function deactivate() {}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,13 @@
-export const DiffContentProviderId = 'aider-diff';
+export interface DocsConfig {
+    title: string;
+    startUrl: string;
+    rootUrl: string;
+    faviconUrl?: string;
+}
+
+export const DiffContentProviderId = 'aider-composer-diff';
 
 export interface DiffParams {
-  // file path
-  original: string;
-  // modified content
-  modified: {
     path: string;
     content: string;
-  };
 }

--- a/src/types/vectordb.d.ts
+++ b/src/types/vectordb.d.ts
@@ -1,0 +1,44 @@
+declare module 'vectordb' {
+    export function connect(path: string): Promise<Database>;
+
+    export interface Database {
+        openTable(name: string): Promise<Table>;
+        createTable(name: string, data: any[]): Promise<Table>;
+    }
+
+    export interface Table {
+        add(data: any[]): Promise<void>;
+        search(vector: number[]): TableSearch;
+        delete(): TableDelete;
+    }
+
+    export interface TableSearch {
+        where(condition: string): TableSearch;
+        limit(n: number): TableSearch;
+        execute(): Promise<any[]>;
+    }
+
+    export interface TableDelete {
+        where(condition: string): TableDelete;
+        execute(): Promise<void>;
+    }
+}
+
+declare module 'vectordb/table' {
+    export interface Table {
+        add(data: any[]): Promise<void>;
+        search(vector: number[]): TableSearch;
+        delete(): TableDelete;
+    }
+
+    export interface TableSearch {
+        where(condition: string): TableSearch;
+        limit(n: number): TableSearch;
+        execute(): Promise<any[]>;
+    }
+
+    export interface TableDelete {
+        where(condition: string): TableDelete;
+        execute(): Promise<void>;
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
 		],
 		"sourceMap": true,
 		"rootDir": "src",
-		"strict": true   /* enable all strict type-checking options */
+		"strict": true, /* enable all strict type-checking options */
+		"allowSyntheticDefaultImports": true,
 		/* Additional Checks */
 		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
 		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -33,7 +33,7 @@
         "tailwind-merge": "^2.5.3",
         "tailwindcss-animate": "^1.0.7",
         "yup": "^1.4.0",
-        "zustand": "^5.0.0-rc.2"
+        "zustand": "^5.0.1"
       },
       "devDependencies": {
         "@emotion/css": "^11.13.4",
@@ -6915,9 +6915,10 @@
       }
     },
     "node_modules/zustand": {
-      "version": "5.0.0-rc.2",
-      "resolved": "https://registry.npmmirror.com/zustand/-/zustand-5.0.0-rc.2.tgz",
-      "integrity": "sha512-o2Nwuvnk8vQBX7CcHL8WfFkZNJdxB/VKeWw0tNglw8p4cypsZ3tRT7rTRTDNeUPFS0qaMBRSKe+fVwL5xpcE3A==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.1.tgz",
+      "integrity": "sha512-pRET7Lao2z+n5R/HduXMio35TncTlSW68WsYBq2Lg1ASspsNGjpwLAsij3RpouyV6+kHMwwwzP0bZPD70/Jx/w==",
+      "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
       },

--- a/ui/package.json
+++ b/ui/package.json
@@ -35,7 +35,7 @@
     "tailwind-merge": "^2.5.3",
     "tailwindcss-animate": "^1.0.7",
     "yup": "^1.4.0",
-    "zustand": "^5.0.0-rc.2"
+    "zustand": "^5.0.1"
   },
   "devDependencies": {
     "@emotion/css": "^11.13.4",

--- a/ui/src/stores/initialDocs.ts
+++ b/ui/src/stores/initialDocs.ts
@@ -1,0 +1,22 @@
+import { DocsConfig } from '../types';
+
+export const initialDocs: DocsConfig[] = [
+    {
+        title: 'React Documentation',
+        startUrl: 'https://react.dev/reference/react',
+        rootUrl: 'https://react.dev',
+        faviconUrl: 'https://react.dev/favicon.ico',
+    },
+    {
+        title: 'TypeScript Documentation',
+        startUrl: 'https://www.typescriptlang.org/docs/',
+        rootUrl: 'https://www.typescriptlang.org',
+        faviconUrl: 'https://www.typescriptlang.org/favicon-32x32.png',
+    },
+    {
+        title: 'Node.js Documentation',
+        startUrl: 'https://nodejs.org/docs/latest/api/',
+        rootUrl: 'https://nodejs.org',
+        faviconUrl: 'https://nodejs.org/favicon.ico',
+    },
+];

--- a/ui/src/stores/useDocsStore.ts
+++ b/ui/src/stores/useDocsStore.ts
@@ -1,0 +1,32 @@
+import { create } from 'zustand';
+import type { StoreApi } from 'zustand';
+import { DocsConfig } from '../types';
+import { initialDocs } from './initialDocs';
+
+interface DocsState {
+    providers: DocsConfig[];
+    addProvider: (provider: DocsConfig) => void;
+    removeProvider: (startUrl: string) => void;
+    setProviders: (providers: DocsConfig[]) => void;
+}
+
+type DocsStore = {
+    setState: StoreApi<DocsState>['setState'];
+    getState: StoreApi<DocsState>['getState'];
+};
+
+export const useDocsStore = create<DocsState>()((set) => ({
+    providers: initialDocs,
+    addProvider: (provider: DocsConfig) =>
+        set((state) => ({
+            providers: [...state.providers, provider],
+        })),
+    removeProvider: (startUrl: string) =>
+        set((state) => ({
+            providers: state.providers.filter((p) => p.startUrl !== startUrl),
+        })),
+    setProviders: (providers: DocsConfig[]) =>
+        set({
+            providers,
+        }),
+}));

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -1,6 +1,21 @@
-type FileItem = { type: 'file'; fsPath: string; path: string; name: string };
+type FileItem = {
+  type: 'file';
+  fsPath: string;
+  path: string;
+  name: string;
+};
 
-export type ChatReferenceItem = FileItem;
+export type DocItem = {
+  type: 'doc';
+  title: string;
+  startUrl: string;
+  rootUrl: string;
+  faviconUrl?: string;
+  name: string;
+  path: string;
+};
+
+export type ChatReferenceItem = FileItem | DocItem;
 
 export interface ChatUserMessage {
   id: string;
@@ -28,4 +43,11 @@ export enum DiffFormat {
   DiffFenced = 'diff-fenced',
   UDiff = 'udiff',
   Whole = 'whole',
+}
+
+export interface DocsConfig {
+  title: string;
+  startUrl: string;
+  rootUrl: string;
+  faviconUrl?: string;
 }


### PR DESCRIPTION
Add a docs crawler using to implement the following crawlers:
- ChromiumCrawler
- ChromiumCrawler
- DefaultCrawler
- specific implementation for github.

following major packages used:
- vectordb
- Puppetteer

This PR is highly inspired by Continue.dev's implementation, and the following resources/topics:
- https://stackoverflow.com/questions/50218402/nodejs-web-crawling-with-node-crawler-or-simplecrawler
- https://www.reddit.com/r/LangChain/comments/1g8scol/efficient_web_crawling_for_keeping_vector/
- https://stackoverflow.com/questions/50154133/how-to-crawl-all-the-internal-urls-of-a-website-using-crawler