### PR TITLE
Fixing API Key Configuration Handling for OpenAI-Compatible APIs

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -142,11 +142,10 @@ class ChatSessionManager:
             # update os env
             config = provider_env_map[setting.provider]
             
-            # explicitly handle configs that only need an api key
             if isinstance(config, str):
                 os.environ[config] = setting.api_key
                 
-            # explicitly handle configs that need multiple env vars, like base urls and api keys
+            # explicitly handle configs that need multiple env variables, like base urls and api keys
             elif isinstance(config, dict):
                 for key, value in config.items():
                     if key == 'api_key':

--- a/server/main.py
+++ b/server/main.py
@@ -141,11 +141,18 @@ class ChatSessionManager:
             model = Model(setting.model)
             # update os env
             config = provider_env_map[setting.provider]
+            
+            # explicitly handle configs that only need an api key
             if isinstance(config, str):
                 os.environ[config] = setting.api_key
+                
+            # explicitly handle configs that need multiple env vars, like base urls and api keys
             elif isinstance(config, dict):
                 for key, value in config.items():
-                    os.environ[key] = value
+                    if key == 'api_key':
+                        os.environ[value] = setting.api_key
+                    elif key == 'base_url':
+                        os.environ[value] = setting.base_url or ''
             self.coder = Coder.create(from_coder=self.coder, main_model=model)
     
     def update_coder(self):


### PR DESCRIPTION
### Problem:
When trying to use an OpenAI-Compatible API, I would get this error:

(note: I added logging during debugging, but that was removed afterwards)
```python
2024-11-14 01:10:56.468 [info] aider-chat: INFO:main:Updating model with new settings: ChatSetting(provider='openai_compatible', api_key='key', model='openai/keyless-gpt-4o-mini', base_url='http://localhost:1337/v1')
2024-11-14 01:10:56.468 [info] aider-chat: INFO:main:No changes to settings; model update not required.
2024-11-14 01:10:56.468 [info] aider-chat: INFO:werkzeug:127.0.0.1 - - [14/Nov/2024 01:10:56] "POST /api/chat/setting HTTP/1.1" 200 -
2024-11-14 01:11:00.240 [info] From Webview: sendChatMessage: hello testing!
2024-11-14 01:11:00.255 [info] aider-chat: INFO:werkzeug:127.0.0.1 - - [14/Nov/2024 01:11:00] "OPTIONS /api/chat HTTP/1.1" 200 -
2024-11-14 01:11:00.282 [info] aider-chat: INFO:werkzeug:127.0.0.1 - - [14/Nov/2024 01:11:00] "POST /api/chat HTTP/1.1" 200 -
2024-11-14 01:11:00.284 [error] From Webview: server error: Unexpected error: litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable
Traceback (most recent call last):
  File "/Users/alex/.pyenv/versions/3.11.8/lib/python3.11/site-packages/litellm/llms/OpenAI/openai.py", line 907, in completion
    raise e
  File "/Users/alex/.pyenv/versions/3.11.8/lib/python3.11/site-packages/litellm/llms/OpenAI/openai.py", line 784, in completion
    return self.streaming(
           ^^^^^^^^^^^^^^^
  File "/Users/alex/.pyenv/versions/3.11.8/lib/python3.11/site-packages/litellm/llms/OpenAI/openai.py", line 1025, in streaming
    openai_client: OpenAI = self._get_openai_client(  # type: ignore
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alex/.pyenv/versions/3.11.8/lib/python3.11/site-packages/litellm/llms/OpenAI/openai.py", line 617, in _get_openai_client
    _new_client = OpenAI(
                  ^^^^^^^
  File "/Users/alex/.pyenv/versions/3.11.8/lib/python3.11/site-packages/openai/_client.py", line 105, in __init__
    raise OpenAIError(
openai.OpenAIError: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable
```
This is because the current implementation is not correctly differentiating between two configuration types:

1.) Configurations where only an API key is required (string type).
2.) Configurations where both a base URL and an API key are needed (dict type). 

### Solution:
My PR modifies the ``update_model`` function to explicitly check the configuration type in ``provider_env_map`` (either string or dict). Depending on the type, it sets the necessary environment variables as follows:

For ``string`` configurations, it directly assigns the ``api_key`` to the designated environment variable **(this is already done in the previous implementation).**
For ``dict`` configurations, it iterates through each key-value pair in the dict, setting all required variables such as ``base_url`` and ``api_key`` to support providers that need multiple environment variables (this is not handled in the previous implementation, it is only set as ``os.environ[key] = value``)

### Testing:
Tested by running an OpenAI-Compatible API setup and verifying that the environment variables are properly set, with successful responses from API calls without authentication errors.
```python
2024-11-14 01:13:16.279 [info] aider-chat: INFO:main:Updating model settings from None to ChatSetting(provider='openai_compatible', api_key='key', model='openai/keyless-gpt-4o-mini', base_url='http://localhost:1337/v1')
2024-11-14 01:13:16.279 [info] aider-chat: INFO:main:Setting API key environment variable: OPENAI_API_KEY = key
2024-11-14 01:13:16.279 [info] aider-chat: INFO:main:Setting base URL environment variable: OPENAI_API_BASE = http://localhost:1337/v1
2024-11-14 01:13:16.280 [info] aider-chat: INFO:main:Model updated successfully.
2024-11-14 01:13:16.280 [info] aider-chat: INFO:werkzeug:127.0.0.1 - - [14/Nov/2024 01:13:16] "POST /api/chat/setting HTTP/1.1" 200 -
2024-11-14 01:13:20.619 [info] Setting button clicked!
2024-11-14 01:13:38.502 [info] aider-chat: INFO:werkzeug:127.0.0.1 - - [14/Nov/2024 01:13:38] "OPTIONS /api/chat/setting HTTP/1.1" 200 -
2024-11-14 01:13:38.503 [info] aider-chat: INFO:werkzeug:127.0.0.1 - - [14/Nov/2024 01:13:38] "POST /api/chat/setting HTTP/1.1" 200 -
2024-11-14 01:13:48.873 [info] From Webview: sendChatMessage: what
2024-11-14 01:13:48.892 [info] aider-chat: INFO:werkzeug:127.0.0.1 - - [14/Nov/2024 01:13:48] "OPTIONS /api/chat HTTP/1.1" 200 -
2024-11-14 01:13:49.064 [info] aider-chat: INFO:httpx:HTTP Request: POST http://localhost:1337/v1/chat/completions "HTTP/1.1 200 OK"
2024-11-14 01:13:49.982 [info] aider-chat: INFO:werkzeug:127.0.0.1 - - [14/Nov/2024 01:13:49] "POST /api/chat HTTP/1.1" 200 -
2024-11-14 01:13:52.813 [info] From Webview: sendChatMessage: hi
2024-11-14 01:13:52.842 [info] aider-chat: INFO:httpx:HTTP Request: POST http://localhost:1337/v1/chat/completions "HTTP/1.1 200 OK"
2024-11-14 01:13:53.580 [info] aider-chat: INFO:werkzeug:127.0.0.1 - - [14/Nov/2024 01:13:53] "POST /api/chat HTTP/1.1" 200 -
2024-11-14 01:13:56.558 [info] Setting button clicked!
```

