### PR TITLE
fix: multiple edits write fail

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -164,16 +164,15 @@ class ChatSessionManager:
             fnames=(item.fs_path for item in self.reference_list if not item.readonly),
             read_only_fnames=(item.fs_path for item in self.reference_list if item.readonly),
         )
-    
+
     def chat(self, data: ChatSessionData):
         need_update_coder = False
         data.reference_list.sort(key=lambda x: x.fs_path)
 
-        if data.chat_type != self.chat_type:
+        if data.chat_type != self.chat_type or data.diff_format != self.diff_format:
             need_update_coder = True
             self.chat_type = data.chat_type
-            if data.diff_format != self.diff_format:
-                self.diff_format = data.diff_format
+            self.diff_format = data.diff_format
         if data.reference_list != self.reference_list:
             need_update_coder = True
             self.reference_list = data.reference_list

--- a/src/webViewProvider.ts
+++ b/src/webViewProvider.ts
@@ -354,12 +354,22 @@ class VscodeReactView implements WebviewViewProvider {
       });
 
       const name = path.basename(data.path);
-      // 打开 diff 编辑器
+
+      // check if there is already a second column
+      const hasSecondColumn = vscode.window.tabGroups.all.length > 1;
+
+      // open diff editor
       await vscode.commands.executeCommand(
         'vscode.diff',
         originalUri,
         modifiedUri,
         `${name} ${isNewFile ? 'Created' : 'Modified'}`,
+        {
+          viewColumn: hasSecondColumn
+            ? vscode.ViewColumn.Two
+            : vscode.ViewColumn.Beside,
+          preview: false,
+        },
       );
     } catch (error) {
       this.outputChannel.error(`Error opening diff: ${error}`);

--- a/src/webViewProvider.ts
+++ b/src/webViewProvider.ts
@@ -355,9 +355,6 @@ class VscodeReactView implements WebviewViewProvider {
 
       const name = path.basename(data.path);
 
-      // check if there is already a second column
-      const hasSecondColumn = vscode.window.tabGroups.all.length > 1;
-
       // open diff editor
       await vscode.commands.executeCommand(
         'vscode.diff',
@@ -365,9 +362,7 @@ class VscodeReactView implements WebviewViewProvider {
         modifiedUri,
         `${name} ${isNewFile ? 'Created' : 'Modified'}`,
         {
-          viewColumn: hasSecondColumn
-            ? vscode.ViewColumn.Two
-            : vscode.ViewColumn.Beside,
+          viewColumn: vscode.ViewColumn.Two,
           preview: false,
         },
       );


### PR DESCRIPTION
#5 when llm wants to edit multiple file, this would emit mulple editor and preview editor will only remain one. so the multiple file write fails.