### PR TITLE
Adding Open VSX publication for non-MSFT platforms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,3 +42,9 @@ jobs:
       #   env:
       #     VSCE_PAT: ${{ secrets.VSCE_PAT }}
       #   run: npx vsce publish -p $VSCE_PAT
+
+      - name: Publish to Open VSX
+        if: ${{ success() }}
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+        run: npx ovsx publish -p $OVSX_PAT


### PR DESCRIPTION
Closes #18 

An Open VSX PAT `OVSX_PAT` is required for `ovsx` to work, see in the [Readme here](https://github.com/eclipse/openvsx/blob/master/cli/README.md)
and stored in Github Secrets